### PR TITLE
Removed peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "eslint-plugin-import": "^2.0.1",
     "stylelint": "^7.5.0"
   },
-  "peerDependencies": {
-    "stylelint": "^7.5.0"
-  },
   "author": "Deloitte Digital Australia (http://deloittedigital.com.au)",
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Sometimes a project will want to use the Stylelint configuration but not include the Stylelint module itself. Currently the following warning is displayed on install:

![image](https://user-images.githubusercontent.com/513363/27359286-4cdccd34-565e-11e7-9627-726aed6c9db4.png)

Example scenarios where this happens:

- The project doesn't have build scripts, and the config is purely used to configure the IDE.
- The build scripts live externally to the project, for example the project is just a small module living in a big project and the big project builds the small module.